### PR TITLE
Preconditioner and Tolerance Consistency Fix

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -1,6 +1,6 @@
 export cg, cg!
 
-cg(A, b, Pl=1; kwargs...) =  cg!(randx(A, b), A, b, Pl; kwargs...)
+cg(A, b, Pl=1; kwargs...) =  cg!(zerox(A,b), A, b, Pl; kwargs...)
 
 function cg!(x, A, b, Pl=1; tol::Real=size(A,2)*eps(), maxiter::Int=size(A,2))
     K = KrylovSubspace(A, length(b), 1, Vector{Adivtype(A,b)}[])
@@ -12,8 +12,9 @@ function cg!(x, K::KrylovSubspace, b, Pl=1;
         tol::Real=size(K.A,2)*eps(), maxiter::Integer=size(K.A,2))
     resnorms = zeros(maxiter)
 
+    tol = tol * norm(b)
     r = b - nextvec(K)
-    p = z = Pl*r
+    p = z = Pl\r
     γ = dot(r, z)
     for iter=1:maxiter
         append!(K, p)
@@ -27,7 +28,7 @@ function cg!(x, K::KrylovSubspace, b, Pl=1;
             resnorms = resnorms[1:iter]
             break
         end
-        z = Pl*r
+        z = Pl\r
         oldγ = γ
         γ = dot(r, z)
         β = γ/oldγ

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -2,7 +2,7 @@ export chebyshev, chebyshev!
 
 chebyshev(A, b, λmin::Real, λmax::Real, Pr=1, n=size(A,2);
           tol::Real=sqrt(eps(typeof(real(b[1])))), maxiter::Int=n^3) =
-    chebyshev!(randx(A, b), A, b, λmin, λmax, Pr, n; tol=tol,maxiter=maxiter)
+    chebyshev!(zerox(A, b), A, b, λmin, λmax, Pr, n; tol=tol,maxiter=maxiter)
 
 function chebyshev!(x, A, b, λmin::Real, λmax::Real, Pr=1, n=size(A,2); tol::Real=sqrt(eps(typeof(real(b[1])))), maxiter::Int=n^3)
 	K = KrylovSubspace(A, n, 1, Adivtype(A, b))
@@ -12,6 +12,7 @@ end
 
 function chebyshev!(x, K::KrylovSubspace, b, λmin::Real, λmax::Real, Pr=1; tol::Real=sqrt(eps(typeof(real(b[1])))), maxiter::Int=K.n^3)
 	K.order=1
+    tol = tol * norm(b)
 	r = b - nextvec(K)
 	d::eltype(b) = (λmax+λmin)/2
 	c::eltype(b) = (λmax-λmin)/2

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -11,6 +11,7 @@ function jacobi!(x, A::AbstractMatrix, b;
 	n = size(A,2)
     xold = copy(x)
     z = zero(Amultype(A, x))
+    tol = tol * norm(b)
 	resnorms = zeros(typeof(real(b[1])), maxiter)
 	for iter=1:maxiter
 		for i=1:n
@@ -41,6 +42,7 @@ function gauss_seidel!(x, A::AbstractMatrix, b;
 	n = size(A,2)
     xold = copy(x)
     z = zero(Amultype(A, x))
+    tol = tol * norm(b)
 	resnorms = zeros(typeof(real(b[1])), maxiter)
 	for iter=1:maxiter
 		for i=1:n
@@ -77,6 +79,7 @@ function sor!(x, A::AbstractMatrix, b, ω::Real;
 	n = size(A,2)
     xold = copy(x)
     z = zero(Amultype(A, x))
+    tol = tol * norm(b)
 	resnorms = zeros(typeof(real(b[1])), maxiter)
 	for iter=1:maxiter
 		for i=1:n
@@ -115,6 +118,7 @@ function ssor!(x, A::AbstractMatrix, b, ω::Real;
 	n = size(A,2)
     xold = copy(x)
     z = zero(Amultype(A, x))
+    tol = tol * norm(b)
 	resnorms = zeros(typeof(real(b[1])), maxiter)
 	for iter=1:maxiter
 		for i=1:n #Do a SOR sweep

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -16,6 +16,10 @@ x,ch = cg(A,rhs;tol=tol, maxiter=2*N)
 # If you start from the exact solution, you should converge immediately
 x2,ch2 = cg!(A\rhs, A, rhs; tol=tol*10)
 @test length(ch2.residuals) <= 1
+# Test with cholfact should converge immediately
+F = cholfact(A)
+x2,ch2 = cg(A, rhs, F)
+@test length(ch2.residuals) <= 2
 
 # CG: test sparse Laplacian
 A = getDivGrad(32,32,32)
@@ -27,6 +31,7 @@ JAC(x) = D.\x
 SGS(x) = L\(D.*(U\x))
 
 rhs = randn(size(A,2))
+rhs = rhs / norm(rhs)
 tol = 1e-5
 # tests with A being matrix
 xCG, = cg(A,rhs;tol=tol,maxiter=100)


### PR DESCRIPTION
There are a few small fixes here.
- Corrects application of preconditioners to `P\x` in cg and gmres.
- Adds preconditioner tests using `Cholesky` and `LU` factorization types
- Changes default initial guess for cg and gmres to `zerox(A,b)`
- Tolerances for cg, gmres, chebyshev, jacobi, gauss_siedel, sor, and ssor are normalized to `norm(b)`
