### PR TITLE
Generify lsqr such that we can do distributed iterative least squares

### DIFF
--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -282,6 +282,8 @@ immutable srft
     l :: Integer
 end
 
+(*)(A::AbstractMatrixFcn, B::srft) = error("method only defined to avoid ambiguity. If you need this method please open a pull request")
+
 @doc doc"""
 Applies a subsampled random Fourier transform to the columns of `A`
 


### PR DESCRIPTION
Instead of some explicit loops, I use `axpy!`s and `scale!`s. It is also necessary to use the input `x` to determine the type of `v` and in the distributed case what the distribution should be. With these changes I'm able to do
```jl
julia> addprocs(4);

julia> using IterativeSolvers
### some ambiguity warnings to be fixed

julia> using DistributedArrays

julia> A = DArray(I -> sprandn(map(length, I)..., 0.1), (1000,100));

julia> b = A*ones(size(A,2)) .+ 0.1drandn(size(A,1));

### some DArray method definitions that are missing, but should be added tomorrow
julia> function (-)(x::DArray, y::DArray)
       if size(x) != size(y)
           error()
       end
       return x .- y
       end
- (generic function with 192 methods)

julia> import Base.LinAlg.Ac_mul_B!

julia> import Base.LinAlg.A_mul_B!

julia> A_mul_B!(y::DistributedArrays.DVector, A::DistributedArrays.DMatrix, x::DistributedArrays.DVector) = A_mul_B!(1.0, A, x, 0.0, y);

julia> Ac_mul_B!(y::DistributedArrays.DVector, A::DistributedArrays.DMatrix, x::DistributedArrays.DVector) = Ac_mul_B!(1.0, A, x, 0.0, y);

julia> lsqr!(dzeros((size(A,2),), procs(A)[1,:]), A,b)
([0.99962,1.00234,0.98718,1.00485,1.02174,0.997757,1.02014,1.00479,1.00567,1.00437  …  0.988358,1.00109,1.01792,0.996253,0.97766,1.02347,1.00663,1.01393,0.996976,0.996617],IterativeSolvers.ConvergenceHistory{Tuple{Float64,Float64,Float64},Array{Float64,1}}(false,(1.4901161193847656e-8,1.4901161193847656e-8,6.7108864e7),38,[32.343385149652846,10.470151377339098,4.638313222837186,3.2522547373009227,3.033699443499982,3.0053908749614084,3.001522643036453,3.001058162079925,3.001020741158147,3.001016172788348,3.0010157316503583,3.0010156865713085,3.001015682205293,3.0010156818010656,3.0010156817636973,3.001015681758667,3.0010156817583074,3.0010156817582705]))
```