### PR TITLE
Add codecov & use correct Coverage syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ notifications:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("IterativeSolvers"); Pkg.test("IterativeSolvers"; coverage=true)'
-    - julia -e 'cd(Pkg.dir("IterativeSolvers")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - julia -e 'cd(Pkg.dir("IterativeSolvers")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coverage.process_folder()); Codecov.submit(Coverage.process_folder())'


### PR DESCRIPTION
The syntax in Coverage.jl has changed. Also, why not have codecov if we have Coveralls?