### PR TITLE
lsmr

### DIFF
--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -24,6 +24,7 @@ include("lanczos-svd-tr.jl")
 
 #Least-squares
 include("lsqr.jl")
+include("lsmr.jl")
 
 #Randomized algorithms
 include("rlinalg.jl")

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -1,0 +1,247 @@
+export lsmr, lsmr!
+
+using Base.LinAlg 
+
+##############################################################################
+## LSMR
+##
+## Minimize ||Ax-b||^2 + λ^2 ||x||^2
+##
+## Adapted from the BSD-licensed Matlab implementation at
+## http://web.stanford.edu/group/SOL/software/lsmr/
+##
+## A is a StridedVecOrMat or anything that implements 
+## A_mul_B!(α, A, b, β, c) updates c -> α Ab + βc
+## Ac_mul_B!(α, A, b, β, c) updates c -> α A'b + βc
+## eltype(A)
+## size(A)
+## (this includes SparseMatrixCSC)
+## x, v, h, hbar are AbstractVectors or anything that implements
+## norm(x)
+## copy!(x1, x2)
+## scale!(x, α)
+## axpy!(α, x1, x2)
+## similar(x, T)
+## length(x)
+## b is an AbstractVector or anything that implements
+## eltype(b)
+## norm(b)
+## copy!(x1, x2)
+## fill!(b, α)
+## scale!(b, α)
+## similar(b, T)
+## length(b)
+
+##############################################################################
+
+
+## Arguments:
+## x is initial x0. Transformed in place to the solution.
+## b equals initial b. Transformed in place
+## v, h, hbar are storage arrays of length size(A, 2)
+function lsmr!(x, A, b, v, h, hbar; 
+    atol::Number = 1e-6, btol::Number = 1e-6, conlim::Number = 1e8, 
+    maxiter::Integer = max(size(A,1), size(A,2)), λ::Number = 0)
+
+    # Sanity-checking
+    m = size(A, 1)
+    n = size(A, 2)
+    length(x) == n || error("x has length $(length(x)) but should have length $n")
+    length(v) == n || error("v has length $(length(v)) but should have length $n")
+    length(h) == n || error("h has length $(length(h)) but should have length $n")
+    length(hbar) == n || error("hbar has length $(length(hbar)) but should have length $n")
+    length(b) == m || error("b has length $(length(b)) but should have length $m")
+
+    T = Adivtype(A, b)
+    Tr = real(T)
+    normrs = Tr[]
+    normArs = Tr[]
+    conlim > 0 ? ctol = convert(Tr, inv(conlim)) : ctol = zero(Tr)
+    # form the first vectors u and v (satisfy  β*u = b,  α*v = A'u)
+    u = A_mul_B!(-1, A, x, 1, b)
+    β = norm(u)
+    β > 0 && scale!(u, inv(β))
+    Ac_mul_B!(1, A, u, 0, v)
+    α = norm(v)
+    α > 0 && scale!(v, inv(α))
+
+    # Initialize variables for 1st iteration.
+    ζbar = α * β
+    αbar = α
+    ρ = one(Tr)
+    ρbar = one(Tr)
+    cbar = one(Tr)
+    sbar = zero(Tr)
+
+    copy!(h, v)
+    fill!(hbar, zero(Tr))
+
+    # Initialize variables for estimation of ||r||.
+    βdd = β
+    βd = zero(Tr)
+    ρdold = one(Tr)
+    τtildeold = zero(Tr)
+    θtilde  = zero(Tr)
+    ζ = zero(Tr)
+    d = zero(Tr)
+
+    # Initialize variables for estimation of ||A|| and cond(A).
+    normA, condA, normx = -one(Tr), -one(Tr), -one(Tr)
+    normA2 = abs2(α)
+    maxrbar = zero(Tr)
+    minrbar = 1e100
+
+    # Items for use in stopping rules.
+    normb = β
+    istop = 0 
+    normr = β
+    normAr = α * β
+    tests = Tuple{Tr, Tr, Tr}[]
+    iter = 0
+    # Exit if b = 0 or A'b = 0.
+    if normAr != 0 
+        while iter < maxiter
+            iter += 1
+            A_mul_B!(1, A, v, -α, u)
+            β = norm(u)
+            if β > 0
+                scale!(u, inv(β))
+                Ac_mul_B!(1, A, u, -β, v)
+                α = norm(v)
+                α > 0 && scale!(v, inv(α))
+            end
+        
+            # Construct rotation Qhat_{k,2k+1}.
+            αhat = hypot(αbar, λ)
+            chat = αbar / αhat
+            shat = λ / αhat
+        
+            # Use a plane rotation (Q_i) to turn B_i to R_i.
+            ρold = ρ
+            ρ = hypot(αhat, β)
+            c = αhat / ρ
+            s = β / ρ
+            θnew = s * α
+            αbar = c * α
+        
+            # Use a plane rotation (Qbar_i) to turn R_i^T to R_i^bar.
+            ρbarold = ρbar
+            ζold = ζ
+            θbar = sbar * ρ
+            ρtemp = cbar * ρ
+            ρbar = hypot(cbar * ρ, θnew)
+            cbar = cbar * ρ / ρbar
+            sbar = θnew / ρbar
+            ζ = cbar * ζbar
+            ζbar = - sbar * ζbar
+        
+            # Update h, h_hat, x.
+            scale!(hbar, - θbar * ρ / (ρold * ρbarold))
+            axpy!(1, h, hbar)
+            axpy!(ζ / (ρ * ρbar), hbar, x)
+            scale!(h, - θnew / ρ)
+            axpy!(1, v, h)
+        
+            ##############################################################################
+            ##
+            ## Estimate of ||r||
+            ##
+            ##############################################################################
+        
+            # Apply rotation Qhat_{k,2k+1}.
+            βacute = chat * βdd
+            βcheck = - shat * βdd
+        
+            # Apply rotation Q_{k,k+1}.
+            βhat = c * βacute
+            βdd = - s * βacute
+        
+            # Apply rotation Qtilde_{k-1}.
+            θtildeold = θtilde
+            ρtildeold = hypot(ρdold, θbar)
+            ctildeold = ρdold / ρtildeold
+            stildeold = θbar / ρtildeold
+            θtilde = stildeold * ρbar
+            ρdold = ctildeold * ρbar
+            βd = - stildeold * βd + ctildeold * βhat
+        
+            τtildeold = (ζold - θtildeold * τtildeold) / ρtildeold
+            τd = (ζ - θtilde * τtildeold) / ρdold
+            d += abs2(βcheck)
+            normr = sqrt(d + abs2(βd - τd) + abs2(βdd))
+        
+            # Estimate ||A||.
+            normA2 += abs2(β)
+            normA  = sqrt(normA2)
+            normA2 += abs2(α)
+        
+            # Estimate cond(A).
+            maxrbar = max(maxrbar, ρbarold)
+            if iter > 1 
+                minrbar = min(minrbar, ρbarold)
+            end
+            condA = max(maxrbar, ρtemp) / min(minrbar, ρtemp)
+        
+            ##############################################################################
+            ##
+            ## Test for convergence
+            ##
+            ##############################################################################
+        
+            # Compute norms for convergence testing.
+            normAr  = abs(ζbar)
+            normx = norm(x)
+        
+            # Now use these norms to estimate certain other quantities,
+            # some of which will be small near a solution.
+            test1 = normr / normb
+            test2 = normAr / (normA * normr)
+            test3 = inv(condA)
+            push!(tests, (test1, test2, test3))
+
+            t1 = test1 / (one(Tr) + normA * normx / normb)
+            rtol = btol + atol * normA * normx / normb      
+            # The following tests guard against extremely small values of
+            # atol, btol or ctol.  (The user may have set any or all of
+            # the parameters atol, btol, conlim  to 0.)
+            # The effect is equivalent to the normAl tests using
+            # atol = eps,  btol = eps,  conlim = 1/eps.
+            if iter >= maxiter istop = 7; break end
+            if 1 + test3 <= 1 istop = 6; break end
+            if 1 + test2 <= 1 istop = 5; break end
+            if 1 + t1 <= 1 istop = 4; break end
+            # Allow for tolerances set by the user.
+            if test3 <= ctol istop = 3; break end
+            if test2 <= atol istop = 2; break end
+            if test1 <= rtol  istop = 1; break end
+        end
+    end
+    converged = istop ∉ (3, 6, 7)
+    tol = (atol, btol, ctol)
+    ch = ConvergenceHistory(converged, tol, 2 * iter, tests)
+    return x, ch
+end
+
+## Arguments:
+## x is initial x0. Transformed in place to the solution.
+function lsmr!(x, A, b; kwargs...)
+    T = Adivtype(A, b)
+    m, n = size(A, 1), size(A, 2)
+    btmp = similar(b, T)
+    copy!(btmp, b)
+    v, h, hbar = similar(x, T), similar(x, T), similar(x, T)
+    lsmr!(x, A, btmp, v, h, hbar; kwargs...)
+end
+
+function lsmr(A, b; kwargs...)
+    lsmr!(zerox(A, b), A, b; kwargs...)
+end
+
+for (name, symbol) in ((:Ac_mul_B!, 'T'), (:A_mul_B!, 'N'))
+    @eval begin
+        function Base.$name(α::Number, A::StridedVecOrMat, x::AbstractVector, β::Number, y::AbstractVector)
+            BLAS.gemm!($symbol, 'N', convert(eltype(y), α), A, x, convert(eltype(y), β), y)
+        end
+    end
+end
+

--- a/test/lsmr.jl
+++ b/test/lsmr.jl
@@ -1,0 +1,199 @@
+using IterativeSolvers
+using FactCheck
+using Base.Test
+
+
+
+# Type used in SOL test
+type Wrapper
+    m::Int
+    n::Int
+end
+Base.size(op::Wrapper, dim::Integer) = (dim == 1) ? op.m :
+                                            (dim == 2) ? op.n : 1
+Base.size(op::Wrapper) = (op.m, op.n)
+Base.eltype(op::Wrapper) = Int
+
+function Base.A_mul_B!(α, A::Wrapper, x, β, y)
+    m, n = size(A)
+    scale!(y, β)
+    y[1] = y[1] + α * x[1]
+    for i = 2:n
+        y[i] = y[i] + i * α * x[i] + (i-1) * α * x[i-1]
+    end
+    for i = n+1:m
+        y[i] = y[i] 
+    end
+    return y
+end
+
+function Base.Ac_mul_B!(α, A::Wrapper, x, β, y)
+    m, n = size(A)
+    mn = min(m, n)
+    scale!(y, β)
+    for i = 1:mn-1
+        y[i] = y[i] + α * i* (x[i]+x[i+1])
+    end
+    y[mn] = y[mn] + α * mn * x[mn]
+    for i = m+1:n
+        y[i] = y[i] 
+    end
+    return y
+end
+
+
+
+# Type used in Dampenedtest
+# solve (A'A + diag(v).^2 ) x = b
+# using LSMR in the augmented space A' = [A ; diag(v)] b' = [b; zeros(size(A, 2)]
+type DampenedVector{Ty, Tx}
+    y::Ty 
+    x::Tx
+end
+Base.eltype(a::DampenedVector) =  promote_type(eltype(a.y), eltype(a.x))
+
+function Base.norm(a::DampenedVector)
+    return sqrt(norm(a.y)^2 + norm(a.x)^2)
+end
+
+function Base.copy!{Ty, Tx}(a::DampenedVector{Ty, Tx}, b::DampenedVector{Ty, Tx})
+    copy!(a.y, b.y)
+    copy!(a.x, b.x)
+    return a
+end
+
+function Base.fill!(a::DampenedVector, α::Number)
+    fill!(a.y, α)
+    fill!(a.x, α)
+    return a
+end
+
+function Base.scale!(a::DampenedVector, α::Number)
+    scale!(a.y, α)
+    scale!(a.x, α)
+    return a
+end
+
+function Base.scale!(a::DampenedVector, α::Number)
+    scale!(a.y, α)
+    scale!(a.x, α)
+    return a
+end
+
+function Base.similar(a::DampenedVector, T)
+    return DampenedVector(similar(a.y, T), similar(a.x, T))
+end
+
+function Base.length(a::DampenedVector)
+    length(a.y) + length(a.x)
+end
+
+
+type DampenedMatrix{TA, Tx}
+    A::TA
+    diagonal::Tx 
+end
+
+Base.eltype(A::DampenedMatrix) = promote_type(eltype(A.A), eltype(A.diagonal))
+
+function Base.size(A::DampenedMatrix, dim::Integer)
+    m, n = size(A.A)
+    l = length(A.diagonal)
+    dim == 1 ? (m + l) : 
+    dim == 2 ? n : 1
+end
+
+function Base.A_mul_B!{TA, Tx, Ty}(α::Number, mw::DampenedMatrix{TA, Tx}, a::Tx, 
+                β::Number, b::DampenedVector{Ty, Tx})
+    if β != 1.
+        if β == 0.
+            fill!(b, 0.)
+        else
+            scale!(b, β)
+        end
+    end
+    A_mul_B!(α, mw.A, a, 1.0, b.y)
+    map!((z, x, y)-> z + α * x * y, b.x, b.x, a, mw.diagonal)
+    return b
+end
+
+function Base.Ac_mul_B!{TA, Tx, Ty}(α::Number, mw::DampenedMatrix{TA, Tx}, a::DampenedVector{Ty, Tx}, 
+                β::Number, b::Tx)
+    if β != 1.
+        if β == 0.
+            fill!(b, 0.)
+        else
+            scale!(b, β)
+        end
+    end
+    Ac_mul_B!(α, mw.A, a.y, 1.0, b)
+    map!((z, x, y)-> z + α * x * y, b, b, a.x, mw.diagonal)  
+    return b
+end
+
+
+
+facts(string("lsmr")) do
+
+
+    context("Small dense matrix") do
+        A = rand(10, 5)
+        b = rand(10)
+        x, = lsmr(A, b)
+        @fact norm(x - A\b) --> less_than(√eps())
+    end
+
+
+    context("SOL test") do
+        # Test adapted from the BSD-licensed Matlab implementation at
+        #    http://www.stanford.edu/group/SOL/software/lsqr.html
+        #              Michael Saunders, Systems Optimization Laboratory,
+        #              Dept of MS&E, Stanford University.
+        #-----------------------------------------------------------------------
+
+        # This is a simple example for testing  LSMR.
+        # It uses the leading m*n submatrix from
+        # A = [ 1
+        #       1 2
+        #         2 3
+        #           3 4
+        #             ...
+        #               n ]
+        # suitably padded by zeros.
+        #
+        # 11 Apr 1996: First version for distribution with lsqr.m.
+        #              Michael Saunders, Dept of EESOR, Stanford University.
+
+        function SOLtest(m, n, damp)
+            A = Wrapper(m, n)
+            xtrue = n:-1:1
+            b = Array(Float64, m)
+            b = float(A_mul_B!(1.0, A, xtrue, 0.0, b))
+            x, = lsmr(A, b, atol = 1e-7, btol = 1e-7, conlim = 1e10, maxiter = 10n)
+            r = A_mul_B!(-1, A, x, 1, b)
+            @fact norm(r) --> less_than_or_equal(1e-4)
+        end
+        SOLtest(10, 10, 0)
+        SOLtest(20, 10, 0)
+        SOLtest(20, 10, 0.1)
+    end
+
+
+
+    context("dampened test") do
+        # Test used to make sure A, b can be generic matrix / vector
+        srand(1234)
+        function DampenedTest(m, n)
+            b = rand(m)
+            A = rand(m, n)
+            v = rand(n)
+            Adampened = DampenedMatrix(A, v)
+            bdampened = DampenedVector(b, zeros(n))
+            x, ch = lsmr(Adampened, bdampened)
+            @fact norm((A'A + diagm(v).^2)x - A'b) --> less_than(1e-3)
+        end
+        DampenedTest(10, 10)
+        DampenedTest(20, 10)
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,6 +202,7 @@ include("lanczos-svd.jl")
 include("lanczos-svd-tr.jl")
 
 include("lsqr.jl")
+include("lsmr.jl")
 
 #Randomized algorithms
 include("rlinalg.jl")


### PR DESCRIPTION
implementation of the lsmr method (see issue [#3531 in METADATA.jl](https://github.com/JuliaLang/METADATA.jl/pull/3531))
I'd like to use this implementation in a code that needs to be efficient, and so there are two differences with lsqr:
- a supplementary signature that allows to pass preallocated arrays (ensuring no array is created within the function)
- Using `A_mul_B!(alpha, A, x, beta, y)` transformations rather than `A_mul_B!(y, A, x)` 

Similar changes could be done in `lsqr`, but I did not touch it.
