### PR TITLE
Fix harmonic restart svdl on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: julia
 os:
-    - osx
     - linux
 julia:
+    - 0.4
     - nightly
 notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("IterativeSolvers"); Pkg.test("IterativeSolvers"; coverage=true)'
-    - julia -e 'cd(Pkg.dir("IterativeSolvers")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coverage.process_folder()); Codecov.submit(Coverage.process_folder())'
+    - julia -e 'Pkg.clone(pwd())'
+    - julia -e 'Pkg.test("IterativeSolvers", coverage=true)'
+after_success:
+    - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("IterativeSolvers")); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(process_folder())'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![IterativeSolvers](http://pkg.julialang.org/badges/IterativeSolvers_0.4.svg)](http://pkg.julialang.org/?pkg=IterativeSolvers&ver=0.4)
 [![Build Status on Linux](https://travis-ci.org/JuliaLang/IterativeSolvers.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/IterativeSolvers.jl)
 [![Build status on Windows](https://ci.appveyor.com/api/projects/status/eaoi7dw2j6qqfskf/branch/master)](https://ci.appveyor.com/project/jiahao/iterativesolvers-jl/branch/master)
-[![Coverage Status](https://img.shields.io/coveralls/JuliaLang/IterativeSolvers.jl.svg)](https://img.shields.io/coveralls/JuliaLang/IterativeSolvers.jl.svg)
+[![Coverage Status](https://coveralls.io/repos/JuliaLang/IterativeSolvers.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaLang/IterativeSolvers.jl?branch=master)
+[![codecov.io](https://codecov.io/github/JuliaLang/IterativeSolvers.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaLang/IterativeSolvers.jl?branch=master)
 
 &copy; 2013---2015 [The Contributors](https://github.com/JuliaLang/IterativeSolvers.jl/contributors). Released under the [MIT License](https://github.com/JuliaLang/julia/blob/master/LICENSE.md).
 


### PR DESCRIPTION
Since JuliaLang/julia#13612, slices of the form `A[end, :]` are now true vectors, not "row vectors".