### PR TITLE
Residual Smoothing for IDR(s) solver.

### DIFF
--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -81,7 +81,7 @@ idrs(A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter = length(b)^2) =
 idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2) =
     idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter)
 
-function idrs_core!{T}(X::T, op, args, C::T, s::Int64, tol::Float64, maxiter::Int64; smoothing::Bool=false)
+function idrs_core!{T}(X::T, op, args, C::T, s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
     R = C - op(X, args...)::T
     normR = vecnorm(R)
     res = typeof(tol)[normR]

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -1,4 +1,4 @@
-import Base.LinAlg.BLAS: axpy!, gemm!
+import Base.LinAlg.BLAS: axpy!
 export idrs, idrs!
 
 ####
@@ -91,7 +91,6 @@ function idrs_core!{T}(X::T, op, args, C::T, s::Int64, tol::Float64, maxiter::In
         X_s = copy(X)
         R_s = copy(R)
         T_s = zeros(R)
-        # gamma = zeros(size(R_s, 1), size(T_s, 1))
     end
 
     if normR <= tol           # Initial guess is a good enough solution

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -81,7 +81,9 @@ idrs(A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter = length(b)^2) =
 idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2) =
     idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter)
 
-function idrs_core!{T}(X::T, op, args, C, s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
+function idrs_core!{T}(X::T, op, args, C,
+    s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
+
     R = C - op(X, args...)::T
     normR = vecnorm(R)
     res = typeof(tol)[normR]
@@ -161,10 +163,16 @@ function idrs_core!{T}(X::T, op, args, C, s::Integer, tol::AbstractFloat, maxite
 
             normR = vecnorm(R)
             if smoothing
-                copy!(T_s, R_s); axpy!(-1., R, T_s) # T_s = R_s - R
-                gamma = vecdot(R_s, T_s)/vecnorm(T_s)^2
-                axpy!(-gamma, T_s, R_s) # R_s = R_s - gamma*T_s
-                copy!(T_s, X_s); axpy!(-1., X, T_s); axpy!(-gamma, T_s, X_s) # X_s = X_s - gamma*(X_s - X)
+                # T_s = R_s - R
+                copy!(T_s, R_s); axpy!(-1., R, T_s)
+
+                gamma = vecdot(R_s, T_s)/vecdot(T_s, T_s)
+
+                # R_s = R_s - gamma*T_s
+                axpy!(-gamma, T_s, R_s)
+                # X_s = X_s - gamma*(X_s - X)
+                copy!(T_s, X_s); axpy!(-1., X, T_s); axpy!(-gamma, T_s, X_s)
+
                 normR = vecnorm(R_s)
             end
             res = [res; normR]
@@ -188,10 +196,16 @@ function idrs_core!{T}(X::T, op, args, C, s::Integer, tol::AbstractFloat, maxite
 
         normR = vecnorm(R)
         if smoothing
-            copy!(T_s, R_s); axpy!(-1., R, T_s) # T_s = R_s - R
-            gamma = vecdot(R_s, T_s)/vecnorm(T_s)^2
-            axpy!(-gamma, T_s, R_s) # R_s = R_s - gamma*T_s
-            copy!(T_s, X_s); axpy!(-1., X, T_s); axpy!(-gamma, T_s, X_s) # X_s = X_s - gamma*(X_s - X)
+            # T_s = R_s - R
+            copy!(T_s, R_s); axpy!(-1., R, T_s)
+
+            gamma = vecdot(R_s, T_s)/vecdot(T_s, T_s)
+
+            # R_s = R_s - gamma*T_s
+            axpy!(-gamma, T_s, R_s)
+            # X_s = X_s - gamma*(X_s - X)
+            copy!(T_s, X_s); axpy!(-1., X, T_s); axpy!(-gamma, T_s, X_s)
+
             normR = vecnorm(R_s)
         end
         iter += 1

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -83,7 +83,7 @@ idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2, sm
     idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter; smoothing=smoothing)
 
 function idrs_core!{T}(X, op, args, C::T,
-    s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
+    s::Number, tol::Number, maxiter::Number; smoothing::Bool=false)
 
     R = C - op(X, args...)::T
     normR = vecnorm(R)
@@ -213,7 +213,7 @@ function idrs_core!{T}(X, op, args, C::T,
         res = [res; normR]
     end
     if smoothing
-        X = copy(X_s)
+        copy!(X, X_s)
     end
     return X, ConvergenceHistory(res[end]<tol, tol, length(res), res)
 end

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -45,6 +45,7 @@ Arguments
             but also  makes the method more expensive.
        tol -- tolerance of the method.
        maxiter -- maximum number of iterations
+       smoothing -- (Logical) specifies if residual smoothing must be applied. Default is false.
 
 
 Output
@@ -75,13 +76,13 @@ References
         http://ta.twi.tudelft.nl/nw/users/gijzen/idrs.m
     [4] IDR(s)' webpage http://ta.twi.tudelft.nl/nw/users/gijzen/IDR.html
 """
-idrs(A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter = length(b)^2) =
-    idrs_core!(zerox(A,b), linsys_op, (A,), b, s, tol, maxiter)
+idrs(A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter = length(b)^2, smoothing=false) =
+    idrs_core!(zerox(A, b), linsys_op, (A,), b, s, tol, maxiter; smoothing=smoothing)
 
-idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2) =
-    idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter)
+idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2, smoothing=false) =
+    idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter; smoothing=smoothing)
 
-function idrs_core!{T}(X::T, op, args, C,
+function idrs_core!{T}(X, op, args, C::T,
     s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
 
     R = C - op(X, args...)::T

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -81,7 +81,7 @@ idrs(A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter = length(b)^2) =
 idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2) =
     idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter)
 
-function idrs_core!{T}(X::T, op, args, C::T, s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
+function idrs_core!{T}(X::T, op, args, C, s::Integer, tol::AbstractFloat, maxiter::Integer; smoothing::Bool=false)
     R = C - op(X, args...)::T
     normR = vecnorm(R)
     res = typeof(tol)[normR]
@@ -110,7 +110,6 @@ function idrs_core!{T}(X::T, op, args, C::T, s::Integer, tol::AbstractFloat, max
     c = zeros(eltype(C),s)
 
     om::eltype(C) = 1
-    iter = 0
     while normR > tol && iter < maxiter
         for i in 1:s,
             f[i] = vecdot(P[i], R)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -1,6 +1,6 @@
 export lsmr, lsmr!
 
-using Base.LinAlg 
+using Base.LinAlg
 
 ##############################################################################
 ## LSMR
@@ -10,7 +10,7 @@ using Base.LinAlg
 ## Adapted from the BSD-licensed Matlab implementation at
 ## http://web.stanford.edu/group/SOL/software/lsmr/
 ##
-## A is a StridedVecOrMat or anything that implements 
+## A is a StridedVecOrMat or anything that implements
 ## A_mul_B!(α, A, b, β, c) updates c -> α Ab + βc
 ## Ac_mul_B!(α, A, b, β, c) updates c -> α A'b + βc
 ## eltype(A)
@@ -39,8 +39,8 @@ using Base.LinAlg
 ## x is initial x0. Transformed in place to the solution.
 ## b equals initial b. Transformed in place
 ## v, h, hbar are storage arrays of length size(A, 2)
-function lsmr!(x, A, b, v, h, hbar; 
-    atol::Number = 1e-6, btol::Number = 1e-6, conlim::Number = 1e8, 
+function lsmr!(x, A, b, v, h, hbar;
+    atol::Number = 1e-6, btol::Number = 1e-6, conlim::Number = 1e8,
     maxiter::Integer = max(size(A,1), size(A,2)), λ::Number = 0)
 
     # Sanity-checking
@@ -93,13 +93,13 @@ function lsmr!(x, A, b, v, h, hbar;
 
     # Items for use in stopping rules.
     normb = β
-    istop = 0 
+    istop = 0
     normr = β
     normAr = α * β
     tests = Tuple{Tr, Tr, Tr}[]
     iter = 0
     # Exit if b = 0 or A'b = 0.
-    if normAr != 0 
+    if normAr != 0
         while iter < maxiter
             iter += 1
             A_mul_B!(1, A, v, -α, u)
@@ -110,12 +110,12 @@ function lsmr!(x, A, b, v, h, hbar;
                 α = norm(v)
                 α > 0 && scale!(v, inv(α))
             end
-        
+
             # Construct rotation Qhat_{k,2k+1}.
             αhat = hypot(αbar, λ)
             chat = αbar / αhat
             shat = λ / αhat
-        
+
             # Use a plane rotation (Q_i) to turn B_i to R_i.
             ρold = ρ
             ρ = hypot(αhat, β)
@@ -123,7 +123,7 @@ function lsmr!(x, A, b, v, h, hbar;
             s = β / ρ
             θnew = s * α
             αbar = c * α
-        
+
             # Use a plane rotation (Qbar_i) to turn R_i^T to R_i^bar.
             ρbarold = ρbar
             ζold = ζ
@@ -134,28 +134,28 @@ function lsmr!(x, A, b, v, h, hbar;
             sbar = θnew / ρbar
             ζ = cbar * ζbar
             ζbar = - sbar * ζbar
-        
+
             # Update h, h_hat, x.
             scale!(hbar, - θbar * ρ / (ρold * ρbarold))
             axpy!(1, h, hbar)
             axpy!(ζ / (ρ * ρbar), hbar, x)
             scale!(h, - θnew / ρ)
             axpy!(1, v, h)
-        
+
             ##############################################################################
             ##
             ## Estimate of ||r||
             ##
             ##############################################################################
-        
+
             # Apply rotation Qhat_{k,2k+1}.
             βacute = chat * βdd
             βcheck = - shat * βdd
-        
+
             # Apply rotation Q_{k,k+1}.
             βhat = c * βacute
             βdd = - s * βacute
-        
+
             # Apply rotation Qtilde_{k-1}.
             θtildeold = θtilde
             ρtildeold = hypot(ρdold, θbar)
@@ -164,34 +164,34 @@ function lsmr!(x, A, b, v, h, hbar;
             θtilde = stildeold * ρbar
             ρdold = ctildeold * ρbar
             βd = - stildeold * βd + ctildeold * βhat
-        
+
             τtildeold = (ζold - θtildeold * τtildeold) / ρtildeold
             τd = (ζ - θtilde * τtildeold) / ρdold
             d += abs2(βcheck)
             normr = sqrt(d + abs2(βd - τd) + abs2(βdd))
-        
+
             # Estimate ||A||.
             normA2 += abs2(β)
             normA  = sqrt(normA2)
             normA2 += abs2(α)
-        
+
             # Estimate cond(A).
             maxrbar = max(maxrbar, ρbarold)
-            if iter > 1 
+            if iter > 1
                 minrbar = min(minrbar, ρbarold)
             end
             condA = max(maxrbar, ρtemp) / min(minrbar, ρtemp)
-        
+
             ##############################################################################
             ##
             ## Test for convergence
             ##
             ##############################################################################
-        
+
             # Compute norms for convergence testing.
             normAr  = abs(ζbar)
             normx = norm(x)
-        
+
             # Now use these norms to estimate certain other quantities,
             # some of which will be small near a solution.
             test1 = normr / normb
@@ -200,7 +200,7 @@ function lsmr!(x, A, b, v, h, hbar;
             push!(tests, (test1, test2, test3))
 
             t1 = test1 / (one(Tr) + normA * normx / normb)
-            rtol = btol + atol * normA * normx / normb      
+            rtol = btol + atol * normA * normx / normb
             # The following tests guard against extremely small values of
             # atol, btol or ctol.  (The user may have set any or all of
             # the parameters atol, btol, conlim  to 0.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,7 +124,8 @@ end
 facts("idrs") do
 
 for T in (Float32, Float64, Complex64, Complex128)
-    context("Matrix{$T}") do
+    # without smoothing
+    context("Matrix{$T}, without residual smoothing") do
 
     A = convert(Matrix{T}, randn(n,n))
     b = convert(Vector{T}, randn(n))
@@ -139,6 +140,21 @@ for T in (Float32, Float64, Complex64, Complex128)
     @fact norm(A*x_idrs - b) --> less_than(√eps(real(one(T))))
     end
 
+    # with smoothing
+    context("Matrix{$T}, with residual smoothing") do
+
+    A = convert(Matrix{T}, randn(n,n))
+    b = convert(Vector{T}, randn(n))
+    if T <: Complex
+        A += im*convert(Matrix{T}, randn(n,n))
+        b += im*convert(Vector{T}, randn(n))
+    end
+    b = b/norm(b)
+
+    x_idrs, c_idrs = idrs(A, b; smoothing=true)
+    @fact c_idrs.isconverged --> true
+    @fact norm(A*x_idrs - b) --> less_than(√eps(real(one(T))))
+    end
 end
 
 for T in (Float64, Complex128)


### PR DESCRIPTION
Hello,

I've added an optional residual smoothing for the Induced Dimension Reduction method. It just follows the algorithm already implemented in python: https://github.com/astudillor/idrs_solver

Br,

Romain.