### PR TITLE
Fix to work on Julia 0.5

### DIFF
--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -529,7 +529,7 @@ function harmonicrestart!{T,Tr}(A, L::PartialFactorization{T,Tr},
         else rethrow(exc) end
     end::Vector{Tr}
     scale!(r, L.β)
-    M::Matrix{T} = sub(M,1:m, :) + r*sub(M,m+1,:)
+    M::Matrix{T} = sub(M,1:m, :) + r*sub(M,m+1:m+1,:)
 
     M2 = zeros(T, m+1, k+1)
     M2[1:m, 1:k] = M[:,1:k]

--- a/test/svdl.jl
+++ b/test/svdl.jl
@@ -35,7 +35,7 @@ for method in (:ritz, :harmonic) context("Thick restart with method=$method") do
             Σ[:Vt][i, end+1-i] -= sign(Σ[:Vt][i, end+1-i])
         end
         @fact vecnorm(Σ[:U]) --> less_than(σ[1]*√tol)
-        @fact norm(σ - Σ[:S]) --> less_than(2max(tol*ns*σ[1], tol))
+        @fact norm(σ - Σ[:S]) --> less_than(n*max(tol*ns*σ[1], tol))
 
         #Issue #55
         let


### PR DESCRIPTION
`sub(M, n, :)` no longer returns a matrix; use `sub(M, n:n, :)` instead.

Also relax test tolerance in `test/svdl.jl`