### PR TITLE
Move precompile before module definition

### DIFF
--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -1,6 +1,5 @@
+__precompile__(true)
 module IterativeSolvers
-
-isdefined(:__precompile__) && __precompile__(true)
 
 include("common.jl")
 include("krylov.jl")


### PR DESCRIPTION
Precompile works fine but the [docs](http://docs.julialang.org/en/latest/manual/modules/#module-initialization-and-precompilation) says it should be before the module definition (and it looks better there too).