### PR TITLE
Remove redundant multiplication dispatch in krylov

### DIFF
--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -1,8 +1,6 @@
 import Base: append!, eye, size
 
-export ConvergenceHistory, KrylovSubspace
-
-*(f::Function, v::AbstractVector)=f(v) #Syntax to mimic matvec product
+export KrylovSubspace
 
 type Eigenpair{S,T}
     val::S


### PR DESCRIPTION
This also removes exporting `ConvergenceHistory` which isn't in that file.